### PR TITLE
add keyserver for raspbian

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -120,10 +120,10 @@ ynh_install_app_dependencies $pkg_dependencies
 
 if [ $encryption = true ]
 then
-ynh_install_extra_app_dependencies --repo="http://http.debian.net/debian buster-backports main" --package="libolm-dev"
+ynh_install_extra_app_dependencies --repo="http://http.debian.net/debian buster-backports main" --package="libolm-dev" --key="https://keyserver.ubuntu.com"
 fi
 
-ynh_install_extra_app_dependencies --repo="http://http.debian.net/debian buster-backports main" --package="golang-go"
+ynh_install_extra_app_dependencies --repo="http://http.debian.net/debian buster-backports main" --package="golang-go" --key="https://keyserver.ubuntu.com"
 
 src_path="$final_path"/src
 mkdir -p $src_path

--- a/scripts/install
+++ b/scripts/install
@@ -120,10 +120,10 @@ ynh_install_app_dependencies $pkg_dependencies
 
 if [ $encryption = true ]
 then
-ynh_install_extra_app_dependencies --repo="http://http.debian.net/debian buster-backports main" --package="libolm-dev" --key="https://keyserver.ubuntu.com"
+ynh_install_extra_app_dependencies --repo="http://http.debian.net/debian buster-backports main" --package="libolm-dev" --key="https://keyserver.ubuntu.com/pks/lookup?search=0x0E98404D386FA1D9&op=get"
 fi
 
-ynh_install_extra_app_dependencies --repo="http://http.debian.net/debian buster-backports main" --package="golang-go" --key="https://keyserver.ubuntu.com"
+ynh_install_extra_app_dependencies --repo="http://http.debian.net/debian buster-backports main" --package="golang-go" --key="https://keyserver.ubuntu.com/pks/lookup?search=0x0E98404D386FA1D9&op=get"
 
 src_path="$final_path"/src
 mkdir -p $src_path


### PR DESCRIPTION
## Problem
- Install for raspbian/armbian is failing #32 

## Solution
- There's a --key arg to ynh_install_extra_deps (i dont remember the exact helper name) where you could feed an https url for the corresponding key

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/mautrix_whatsapp_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/mautrix_whatsapp_ynh%20PR-NUM-%20(USERNAME)/)  
