### PR TITLE
Add systemd recommended hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) 
 ** Attention: always backup and restore the Yunohost matrix_synapse et mautrix_whatsapp apps together!**
 
 
-**Shipped version:** 0.6.0~ynh1
+**Shipped version:** 0.6.0~ynh2
 ## Disclaimers / important information
 
 ### List of known public services

--- a/README_fr.md
+++ b/README_fr.md
@@ -24,7 +24,7 @@ C'est pourquoi [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_y
 ** Attention : sauvegardez et restaurez toujours les deux applications Yunohost matrix_synapse et mautrix_whatsapp en même temps!**
 
 
-**Version incluse :** 0.6.0~ynh1
+**Version incluse :** 0.6.0~ynh2
 ## Avertissements / informations importantes
 
 ### Liste de passerelles publiques

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -11,5 +11,27 @@ ExecStart=/opt/yunohost/__APP__/mautrix-whatsapp -c=/opt/yunohost/__APP__/config
 Restart=always
 RestartSec=3
 
+# Optional hardening to improve security
+ReadWritePaths=/opt/mautrix-whatsapp
+NoNewPrivileges=yes
+MemoryDenyWriteExecute=true
+PrivateDevices=yes
+PrivateTmp=yes
+ProtectHome=yes
+ProtectSystem=strict
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+LockPersonality=true
+ProtectKernelLogs=true
+ProtectKernelTunables=true
+ProtectHostname=true
+ProtectKernelModules=true
+PrivateUsers=true
+ProtectClock=true
+SystemCallArchitectures=native
+SystemCallErrorNumber=EPERM
+SystemCallFilter=@system-service
+
 [Install]
 WantedBy=multi-user.target

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -12,7 +12,7 @@ Restart=always
 RestartSec=3
 
 # Optional hardening to improve security
-ReadWritePaths=/opt/mautrix-whatsapp
+ReadWritePaths=/opt/yunohost/__APP__
 NoNewPrivileges=yes
 MemoryDenyWriteExecute=true
 PrivateDevices=yes

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Matrix / Synapse puppeting bridge for WhatsApp",
         "fr": "Passerelle Matrix / Synapse pour WhatsApp"
     },
-    "version": "0.6.0~ynh1",
+    "version": "0.6.0~ynh2",
     "url": "https://github.com/mautrix/whatsapp",
     "upstream": {
         "license": "AGPL-3.0-or-later",

--- a/scripts/install
+++ b/scripts/install
@@ -107,8 +107,9 @@ ynh_exec_warn_less ynh_install_app_dependencies $pkg_dependencies
 #=================================================
 ynh_script_progression --message="Configuring system user..." --weight=1
 
-# Create a system user
-ynh_system_user_create --username=$app
+# Create a system user and set home dir to /opt/yunohost/$app so systemd hardening works
+# See more: https://docs.mau.fi/bridges/go/setup.html?bridge=whatsapp#systemd-service
+ynh_system_user_create --username=$app --home_dir=/opt/yunohost/$app
 
 #=================================================
 # CREATE A POSTGRESQL DATABASE

--- a/scripts/remove
+++ b/scripts/remove
@@ -120,4 +120,4 @@ ynh_system_user_delete --username=$app
 # END OF SCRIPT
 #=================================================
 
-ynh_script_progression --message="Removal of $app completed" --time --last
+ynh_script_progression --message="Removal of $app completed" --last

--- a/scripts/restore
+++ b/scripts/restore
@@ -66,8 +66,9 @@ test ! -d $final_path || ynh_die --message="There is already a directory: $final
 #=================================================
 ynh_script_progression --message="Recreating the dedicated system user..." --weight=1
 
-# Create the dedicated user (if not existing)
-ynh_system_user_create --username=$app
+# Create a dedicated user (if not existing) and set home dir to /opt/yunohost/$app so systemd hardening works
+# See more: https://docs.mau.fi/bridges/go/setup.html?bridge=whatsapp#systemd-service
+ynh_system_user_create --username=$app --home_dir=/opt/yunohost/$app
 
 #=================================================
 # RESTORE THE APP MAIN DIR

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -136,7 +136,11 @@ ynh_script_progression --message="Making sure dedicated system user exists..." -
 
 # Create a dedicated user (if not existing) and set home dir to /opt/yunohost/$app so systemd hardening works
 # See more: https://docs.mau.fi/bridges/go/setup.html?bridge=whatsapp#systemd-service
-ynh_system_user_create --username=$app --home_dir=/opt/yunohost/$app
+if ynh_system_user_exists -u "$app"; then
+  usermod --home /opt/yunohost/$app $app
+else
+  ynh_system_user_create --username=$app --home_dir=/opt/yunohost/$app
+fi
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -134,8 +134,9 @@ ynh_exec_warn_less ynh_install_app_dependencies $pkg_dependencies
 #=================================================
 ynh_script_progression --message="Making sure dedicated system user exists..." --weight=8
 
-# Create a dedicated user (if not existing)
-ynh_system_user_create --username=$app
+# Create a dedicated user (if not existing) and set home dir to /opt/yunohost/$app so systemd hardening works
+# See more: https://docs.mau.fi/bridges/go/setup.html?bridge=whatsapp#systemd-service
+ynh_system_user_create --username=$app --home_dir=/opt/yunohost/$app
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE


### PR DESCRIPTION
## Description
Added some systemd optional hardening as per recent official docs from Mautrix.
See: https://docs.mau.fi/bridges/go/setup.html?bridge=whatsapp#systemd-service

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
