### PR TITLE
Testing to master [update to v0.7.1]

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) 
 ** Attention: always backup and restore the Yunohost matrix_synapse et mautrix_whatsapp apps together!**
 
 
-**Shipped version:** 0.7.0~ynh2
-
+**Shipped version:** 0.7.1~ynh1
 ## Disclaimers / important information
 
 ## List of known public services

--- a/README_fr.md
+++ b/README_fr.md
@@ -24,8 +24,7 @@ C'est pourquoi [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_y
 ** Attention : sauvegardez et restaurez toujours les deux applications Yunohost matrix_synapse et mautrix_whatsapp en même temps!**
 
 
-**Version incluse :** 0.7.0~ynh2
-
+**Version incluse :** 0.7.1~ynh1
 ## Avertissements / informations importantes
 
 ## Liste de passerelles publiques

--- a/conf/amd64.src
+++ b/conf/amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/mautrix/whatsapp/releases/download/v0.7.0/mautrix-whatsapp-amd64
-SOURCE_SUM=13b43350e3beabcccd5cce51d3562c0eed703b4075674143d13921fa3f9e6400
+SOURCE_URL=https://github.com/mautrix/whatsapp/releases/download/v0.7.1/mautrix-whatsapp-amd64
+SOURCE_SUM=0679bc54f825b202d9498f6e079386d3473369dde2e3c656b1a5a067249105f2
 SOURCE_SUM_PRG=sha256sum
 SOURCE_IN_SUBDIR=false
 SOURCE_FILENAME=mautrix-whatsapp

--- a/conf/arm64.src
+++ b/conf/arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/mautrix/whatsapp/releases/download/v0.7.0/mautrix-whatsapp-arm64
-SOURCE_SUM=90157e29087320de779a285c308e9aca1a0f052a9e84c4d071e2fbdb3a2c6e31
+SOURCE_URL=https://github.com/mautrix/whatsapp/releases/download/v0.7.1/mautrix-whatsapp-arm64
+SOURCE_SUM=a537598b6e63d71620afe8b7d8f05744524fb5c5bf1a54d4b5a404e3033556ad
 SOURCE_SUM_PRG=sha256sum
 SOURCE_IN_SUBDIR=false
 SOURCE_FILENAME=mautrix-whatsapp

--- a/conf/armhf.src
+++ b/conf/armhf.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/mautrix/whatsapp/releases/download/v0.7.0/mautrix-whatsapp-arm
-SOURCE_SUM=54c0c20d5c6a2997d99cdeb469eebf786ce0593f95582e98da318e178ab364ef
+SOURCE_URL=https://github.com/mautrix/whatsapp/releases/download/v0.7.1/mautrix-whatsapp-arm
+SOURCE_SUM=25424f6b57563127387c1fd11337ce1a08e8c18d493808f99caa043bd85e538d
 SOURCE_SUM_PRG=sha256sum
 SOURCE_IN_SUBDIR=false
 SOURCE_FILENAME=mautrix-whatsapp

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -152,6 +152,12 @@ bridge:
         # provisioning endpoint is used or when a message comes in from that
         # chat.
         max_initial_conversations: -1
+        # If this value is greater than 0, then if the conversation's last
+        # message was more than this number of hours ago, then the conversation
+        # will automatically be marked it as read.
+        # Conversations that have a last message that is less than this number
+        # of hours ago will have their unread status synced from WhatsApp.
+        unread_hours_threshold: 0
         # Settings for immediate backfills. These backfills should generally be
         # small and their main purpose is to populate each of the initial chats
         # (as configured by max_initial_conversations) with a few messages so
@@ -234,7 +240,10 @@ bridge:
     login_shared_secret_map:
         example.com: foobar
     # Should the bridge explicitly set the avatar and room name for private chat portal rooms?
+    # This is implicitly enabled in encrypted rooms.
     private_chat_portal_meta: false
+    # Should group members be synced in parallel? This makes member sync faster
+    parallel_member_sync: false
     # Should Matrix m.notice-type messages be bridged?
     bridge_notices: true
     # Set this to true to tell the bridge to re-send m.bridge events to all rooms on the next run.
@@ -287,6 +296,9 @@ bridge:
     # Send captions in the same message as images. This will send data compatible with both MSC2530 and MSC3552.
     # This is currently not supported in most clients.
     caption_in_message: false
+    # Should Matrix edits be bridged to WhatsApp edits?
+    # Official WhatsApp clients don't render edits yet, but once they do, the bridge should work with them right away.
+    send_whatsapp_edits: false
     # Maximum time for handling Matrix events. Duration strings formatted for https://pkg.go.dev/time#ParseDuration
     # Null means there's no enforced timeout.
     message_handling_timeout:

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Matrix / Synapse puppeting bridge for WhatsApp",
         "fr": "Passerelle Matrix / Synapse pour WhatsApp"
     },
-    "version": "0.7.0~ynh2",
+    "version": "0.7.1~ynh1",
     "url": "https://github.com/mautrix/whatsapp",
     "upstream": {
         "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Notes
- Added support for wa.me/qr links in !wa resolve-link.
- Added option to sync group members in parallel to speed up syncing large groups.
- Added initial support for WhatsApp message editing.
- Sending edits will be disabled by default until official WhatsApp clients start rendering edits.
- Changed private_chat_portal_meta config option to be implicitly enabled in encrypted rooms, matching the behavior of other mautrix bridges.
- Updated media bridging to check homeserver media size limit before downloading media to avoid running out of memory.
- The bridge may still run out of ram when bridging files if your homeserver has a large media size limit and a low bridge memory limit.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
