### PR TITLE
[fix] Backup db empty

### DIFF
--- a/README_fr.md
+++ b/README_fr.md
@@ -5,15 +5,15 @@ It shall NOT be edited by hand.
 
 # Matrix-WhatsApp bridge pour YunoHost
 
-[![Niveau d'intégration](https://dash.yunohost.org/integration/mautrix_whatsapp.svg)](https://dash.yunohost.org/appci/app/mautrix_whatsapp) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/mautrix_whatsapp.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/mautrix_whatsapp.maintain.svg)  
+[![Niveau d’intégration](https://dash.yunohost.org/integration/mautrix_whatsapp.svg)](https://dash.yunohost.org/appci/app/mautrix_whatsapp) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/mautrix_whatsapp.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/mautrix_whatsapp.maintain.svg)  
 [![Installer Matrix-WhatsApp bridge avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=mautrix_whatsapp)
 
 *[Read this readme in english.](./README.md)*
 
-> *Ce package vous permet d'installer Matrix-WhatsApp bridge rapidement et simplement sur un serveur YunoHost.
-Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour savoir comment l'installer et en profiter.*
+> *Ce package vous permet d’installer Matrix-WhatsApp bridge rapidement et simplement sur un serveur YunoHost.
+Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour savoir comment l’installer et en profiter.*
 
-## Vue d'ensemble
+## Vue d’ensemble
 
 Une passerelle entre Matrix et WhatsApp empaquetée comme un service YunoHost.
 Les messages, médias et notifications sont relayées entre un compte WhatsApp et un compte Matrix.
@@ -106,9 +106,9 @@ Si vous devez téléverser vos fichiers log quelque-part, soyez avertis qu'ils c
 
 ## Documentations et ressources
 
-* Site officiel de l'app : <https://maunium.net/go/mautrix-whatsapp/>
-* Documentation officielle de l'admin : <https://docs.mau.fi/bridges/go/whatsapp/index.html>
-* Dépôt de code officiel de l'app : <https://github.com/mautrix/whatsapp>
+* Site officiel de l’app : <https://maunium.net/go/mautrix-whatsapp/>
+* Documentation officielle de l’admin : <https://docs.mau.fi/bridges/go/whatsapp/index.html>
+* Dépôt de code officiel de l’app : <https://github.com/mautrix/whatsapp>
 * Documentation YunoHost pour cette app : <https://yunohost.org/app_mautrix_whatsapp>
 * Signaler un bug : <https://github.com/YunoHost-Apps/mautrix_whatsapp_ynh/issues>
 
@@ -124,4 +124,4 @@ ou
 sudo yunohost app upgrade mautrix_whatsapp -u https://github.com/YunoHost-Apps/mautrix_whatsapp_ynh/tree/testing --debug
 ```
 
-**Plus d'infos sur le packaging d'applications :** <https://yunohost.org/packaging_apps>
+**Plus d’infos sur le packaging d’applications :** <https://yunohost.org/packaging_apps>

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -89,7 +89,7 @@ then
 fi
 if [ -z "$db_name" ]
 then
-    db_name=$(ynh_app_setting_get --app=$app --key=$app)
+    db_name=$(ynh_app_setting_get --app=$app --key=mautrix_whatsapp_db_name)
     ynh_app_setting_set --app=$app --key=db_name --value=$db_name
 fi
 if [ -z "$db_pwd" ]


### PR DESCRIPTION
## Problem

The db_name settings is empty due to a bad migration

## Solution

put mautrix_whatsapp_db_name into db_name (without this the db.sql is generated but with quasi anything inside /o\ )

## PR Status

Ready

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
