### PR TITLE
Improve systemd security, fix encryption wrong value and remove local option

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -33,5 +33,17 @@ SystemCallArchitectures=native
 SystemCallErrorNumber=EPERM
 SystemCallFilter=@system-service
 
+# Denying access to capabilities that should not be relevant for webapps
+# Doc: https://man7.org/linux/man-pages/man7/capabilities.7.html
+CapabilityBoundingSet=~CAP_RAWIO CAP_MKNOD
+CapabilityBoundingSet=~CAP_AUDIT_CONTROL CAP_AUDIT_READ CAP_AUDIT_WRITE
+CapabilityBoundingSet=~CAP_SYS_BOOT CAP_SYS_TIME CAP_SYS_MODULE CAP_SYS_PACCT
+CapabilityBoundingSet=~CAP_LEASE CAP_LINUX_IMMUTABLE CAP_IPC_LOCK
+CapabilityBoundingSet=~CAP_BLOCK_SUSPEND CAP_WAKE_ALARM
+CapabilityBoundingSet=~CAP_SYS_TTY_CONFIG
+CapabilityBoundingSet=~CAP_MAC_ADMIN CAP_MAC_OVERRIDE
+CapabilityBoundingSet=~CAP_NET_ADMIN CAP_NET_BROADCAST CAP_NET_RAW
+CapabilityBoundingSet=~CAP_SYS_ADMIN CAP_SYS_PTRACE CAP_SYSLOG
+
 [Install]
 WantedBy=multi-user.target

--- a/manifest.json
+++ b/manifest.json
@@ -105,8 +105,8 @@
                 },
                 "example": "@johndoe:server.name or server.name or *",
                 "help": {
-                    "en": "A remote or local user (@johndoe:server.name), a remote server (matrix.org), or all remote/local servers (*) can be authorized.\nGive the Matrix server_name, not the full domain/URL.\nIt is also possible to specify multiple values by separating them with comma. Example: @johndoe:server.name,domain.tld,matrix.org",
-                    "fr": "Un compte local ou distant (@johndoe:server.name), un serveur distant (matrix.org), ou tous les serveurs remote/local (*).\nDonner le nom du serveur Matrix, pas le domaine/URL complet\nIl est également possible de spécifier plusieurs valeurs en les séparant par une virgule. Exemple : @johndoe:server.name,domain.tld,matrix.org"
+                    "en": "A remote or local user (@johndoe:server.name),the local server (server.name), a remote server (matrix.org), or all remote/local servers (*) can be authorized.\nGive the Matrix server_name, not the full domain/URL.\nIt is also possible to specify multiple values by separating them with comma. Example: @johndoe:server.name,domain.tld,matrix.org",
+                    "fr": "Un compte local ou distant (@johndoe:server.name), le serveur local (server.name), un serveur distant (matrix.org), ou tous les serveurs remote/local (*).\nDonner le nom du serveur Matrix, pas le domaine/URL complet\nIl est également possible de spécifier plusieurs valeurs en les séparant par une virgule. Exemple : @johndoe:server.name,domain.tld,matrix.org"
                 }
             }
         ]

--- a/scripts/install
+++ b/scripts/install
@@ -44,9 +44,13 @@ server_name=$(ynh_app_setting_get --app $synapse_instance --key server_name)
 domain=$(ynh_app_setting_get --app $synapse_instance --key domain)
 synapse_db_name="matrix_$synapse_instance"
 
-if [ "$listuser" == "local" ]
+# This is needed to convert the value from the manifest to a valid value for the config.yaml file.
+# Without this the install script will throw a warning.
+if [ "$encryption" -eq "1" ]
 then
-	listuser="$server_name"
+  encryption="true"
+else
+  encryption="false"
 fi
 
 #=================================================


### PR DESCRIPTION
## Notes
- Improve systemd security to pass linter checks
- Fix encryption warning during install

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
