### PR TITLE
Fix log permissions after new log options in config file

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -442,7 +442,7 @@ logging:
       format: pretty-colored
     - type: file
       format: json
-      filename: /var/log/__APP__
+      filename: /var/log/__APP__/__APP__.log
       max_size: 100
       max_backups: 10
       compress: true

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -7,12 +7,12 @@ Type=simple
 User=__APP__
 Group=__APP__
 WorkingDirectory=__FINALPATH__/
-ExecStart=__FINALPATH__/mautrix-whatsapp -c=__FINALPATH__/config.yaml >> /var/log/__APP__/__APP__.log 2>&1
+ExecStart=__FINALPATH__/mautrix-whatsapp -c=__FINALPATH__/config.yaml
 Restart=always
 RestartSec=3
 
 # Optional hardening to improve security
-ReadWritePaths=__FINALPATH__/
+ReadWritePaths=__FINALPATH__/ /var/log/__APP__
 NoNewPrivileges=yes
 MemoryDenyWriteExecute=true
 PrivateDevices=yes


### PR DESCRIPTION
## Problem

- After the changes in the logging section of the config file, the app tries create a backup logging file and manage the rotation of the logging file but fails due to Systemd hardening.

## Solution

- Adjust logging section and Systemd hardening to allow the app to write on specific folder for logging.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
