### PR TITLE
Fix updater new releases

### DIFF
--- a/.github/workflows/updater.sh
+++ b/.github/workflows/updater.sh
@@ -14,6 +14,7 @@
 #=================================================
 
 # Fetching information
+app="mautrix-whatsapp"
 current_version=$(yq ".version" manifest.toml | cut -d '~' -f 1 -)
 repo=$(yq ".upstream.code" manifest.toml | sed 's/https:\/\/github.com\///')
 # Some jq magic is needed, because the latest upstream release is not always the latest version (e.g. security patches for older versions)
@@ -64,13 +65,13 @@ echo "Handling asset at $asset_url"
 # Here we base the source file name upon a unique keyword in the assets url (admin vs. update)
 # Leave $src empty to ignore the asset
 case $asset_url in
-  *"amd64")
+  *"$app-amd64")
     src="amd64"
     ;;
-  *"arm")
+  *"$app-arm")
     src="armhf"
     ;;
-  *"arm64")
+  *"$app-arm64")
     src="arm64"
     ;;
   *)
@@ -91,7 +92,7 @@ curl --silent -4 -L $tarball -o "$tempdir/$version"
 checksum=$(sha256sum "$tempdir/$filename" | head -c 64)
 
 # Rewrite source file
-sed -i "s|$src.url.*|src.url = \"$asset_url\"|g" manifest.toml
+sed -i "s|$src.url.*|$src.url = \"$asset_url\"|g" manifest.toml
 sed -i "s|$src.sha256.*|$src.sha256 = \"$checksum\"|g" manifest.toml
 
 else

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) 
 * Official app website: <https://maunium.net/go/mautrix-whatsapp/>
 * Official admin documentation: <https://docs.mau.fi/bridges/go/whatsapp/index.html>
 * Upstream app code repository: <https://github.com/mautrix/whatsapp>
-* YunoHost documentation for this app: <https://yunohost.org/app_mautrix_whatsapp>
 * Report a bug: <https://github.com/YunoHost-Apps/mautrix_whatsapp_ynh/issues>
 
 ## Developer info

--- a/README_fr.md
+++ b/README_fr.md
@@ -31,7 +31,6 @@ C'est pourquoi [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_y
 * Site officiel de l’app : <https://maunium.net/go/mautrix-whatsapp/>
 * Documentation officielle de l’admin : <https://docs.mau.fi/bridges/go/whatsapp/index.html>
 * Dépôt de code officiel de l’app : <https://github.com/mautrix/whatsapp>
-* Documentation YunoHost pour cette app : <https://yunohost.org/app_mautrix_whatsapp>
 * Signaler un bug : <https://github.com/YunoHost-Apps/mautrix_whatsapp_ynh/issues>
 
 ## Informations pour les développeurs


### PR DESCRIPTION
## Problem

- Updater outputted wrong `manifest.toml` values because new releases have been added to `mautrix-whatsapp` package and it broke the logic of parsing the releases. Also there was a typo in some sed line.

## Solution

- Fixed switch cases to avoid parsing unwanted releases and fixed typo.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
