### PR TITLE
Testing to master [v0.10.6]

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,14 @@ Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) 
 
 ** Attention: always backup and restore the Yunohost matrix_synapse et mautrix_whatsapp apps together!**
 
-
-**Shipped version:** 0.10.5~ynh1
+**Shipped version:** 0.10.6~ynh1
 ## Documentation and resources
 
-* Official app website: <https://maunium.net/go/mautrix-whatsapp/>
-* Official admin documentation: <https://docs.mau.fi/bridges/go/whatsapp/index.html>
-* Upstream app code repository: <https://github.com/mautrix/whatsapp>
-* YunoHost Store: <https://apps.yunohost.org/app/mautrix_whatsapp>
-* Report a bug: <https://github.com/YunoHost-Apps/mautrix_whatsapp_ynh/issues>
+- Official app website: <https://maunium.net/go/mautrix-whatsapp/>
+- Official admin documentation: <https://docs.mau.fi/bridges/go/whatsapp/index.html>
+- Upstream app code repository: <https://github.com/mautrix/whatsapp>
+- YunoHost Store: <https://apps.yunohost.org/app/mautrix_whatsapp>
+- Report a bug: <https://github.com/YunoHost-Apps/mautrix_whatsapp_ynh/issues>
 
 ## Developer info
 
@@ -40,7 +39,7 @@ Please send your pull request to the [testing branch](https://github.com/YunoHos
 
 To try the testing branch, please proceed like that.
 
-``` bash
+```bash
 sudo yunohost app install https://github.com/YunoHost-Apps/mautrix_whatsapp_ynh/tree/testing --debug
 or
 sudo yunohost app upgrade mautrix_whatsapp -u https://github.com/YunoHost-Apps/mautrix_whatsapp_ynh/tree/testing --debug

--- a/README_fr.md
+++ b/README_fr.md
@@ -24,15 +24,14 @@ C'est pourquoi [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_y
 
 ** Attention : sauvegardez et restaurez toujours les deux applications Yunohost matrix_synapse et mautrix_whatsapp en même temps!**
 
-
-**Version incluse :** 0.10.5~ynh1
+**Version incluse :** 0.10.6~ynh1
 ## Documentations et ressources
 
-* Site officiel de l’app : <https://maunium.net/go/mautrix-whatsapp/>
-* Documentation officielle de l’admin : <https://docs.mau.fi/bridges/go/whatsapp/index.html>
-* Dépôt de code officiel de l’app : <https://github.com/mautrix/whatsapp>
-* YunoHost Store: <https://apps.yunohost.org/app/mautrix_whatsapp>
-* Signaler un bug : <https://github.com/YunoHost-Apps/mautrix_whatsapp_ynh/issues>
+- Site officiel de l’app : <https://maunium.net/go/mautrix-whatsapp/>
+- Documentation officielle de l’admin : <https://docs.mau.fi/bridges/go/whatsapp/index.html>
+- Dépôt de code officiel de l’app : <https://github.com/mautrix/whatsapp>
+- YunoHost Store : <https://apps.yunohost.org/app/mautrix_whatsapp>
+- Signaler un bug : <https://github.com/YunoHost-Apps/mautrix_whatsapp_ynh/issues>
 
 ## Informations pour les développeurs
 
@@ -40,7 +39,7 @@ Merci de faire vos pull request sur la [branche testing](https://github.com/Yuno
 
 Pour essayer la branche testing, procédez comme suit.
 
-``` bash
+```bash
 sudo yunohost app install https://github.com/YunoHost-Apps/mautrix_whatsapp_ynh/tree/testing --debug
 ou
 sudo yunohost app upgrade mautrix_whatsapp -u https://github.com/YunoHost-Apps/mautrix_whatsapp_ynh/tree/testing --debug

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Matrix-WhatsApp bridge"
 
 description.en = "Matrix / Synapse puppeting bridge for WhatsApp"
 description.fr = "Passerelle Matrix / Synapse pour WhatsApp"
-version = "0.10.5~ynh1"
+version = "0.10.6~ynh1"
 
 maintainers = ["thardev"]
 
@@ -105,12 +105,12 @@ main.default = 8449
 in_subdir = false
 extract = false
 rename = "mautrix-whatsapp"
-amd64.url = "https://github.com/mautrix/whatsapp/releases/download/v0.10.5/mautrix-whatsapp-amd64"
-amd64.sha256 = "f8bce52acaba0393bba42d7891cb0910b4c90179a75b2caf2b499c3331e2a552"
-arm64.url = "https://github.com/mautrix/whatsapp/releases/download/v0.10.5/mautrix-whatsapp-arm64"
-arm64.sha256 = "9b046ee43d1da1242effc18a3c4f6a4d80782beebee3f3d076a6a6cbbcb1d91c"
-armhf.url = "https://github.com/mautrix/whatsapp/releases/download/v0.10.5/mautrix-whatsapp-arm"
-armhf.sha256 = "b5866bc24efd98f24dbe3b834489f86d976b0bb3da49883c5622cf34cdf20562"
+amd64.url = "https://github.com/mautrix/whatsapp/releases/download/v0.10.6/mautrix-whatsapp-amd64"
+amd64.sha256 = "78367a955ced9298cc3a0d75aed9629582f4608b900de2116c8af8cb5db6389a"
+arm64.url = "https://github.com/mautrix/whatsapp/releases/download/v0.10.6/mautrix-whatsapp-arm64"
+arm64.sha256 = "685c337eb1c2d0fe4ada62208127e9be7683efe61328959b68fa2111b821c476"
+armhf.url = "https://github.com/mautrix/whatsapp/releases/download/v0.10.6/mautrix-whatsapp-arm"
+armhf.sha256 = "760d92fcde5e2da9f3d509d7cea1be9c59ce96eb3987344d82989e9ddc1b241d"
 
 autoupdate.strategy = "latest_github_release"
 autoupdate.asset.amd64 = "^mautrix-whatsapp-amd64$"


### PR DESCRIPTION
## Notes

- Bumped minimum Go version to 1.21.
- Added 8-letter code pairing support to provisioning API.
- Added more bugs to fix later.
- Renamed default branch from master to main.


## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
