### PR TITLE
Migration upgrade to 0.11.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Matrix / Synapse puppeting bridge for WhatsApp
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://maunium.net/go/mautrix-whatsapp/)
-[![Version: 0.12.1~ynh1](https://img.shields.io/badge/Version-0.12.1~ynh1-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/mautrix_whatsapp/)
+[![Version: 0.11.2~ynh1](https://img.shields.io/badge/Version-0.11.2~ynh1-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/mautrix_whatsapp/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/mautrix_whatsapp"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Matrix-WhatsApp bridge"
 
 description.en = "Matrix / Synapse puppeting bridge for WhatsApp"
 description.fr = "Passerelle Matrix / Synapse pour WhatsApp"
-version = "0.12.1~ynh1"
+version = "0.11.2~ynh1"
 
 maintainers = ["thardev"]
 
@@ -100,12 +100,12 @@ main.default = 8449
 in_subdir = false
 extract = false
 rename = "mautrix-whatsapp"
-amd64.url = "https://github.com/mautrix/whatsapp/releases/download/v0.12.1/mautrix-whatsapp-amd64"
-amd64.sha256 = "78733edefa316a1521d6c4c72e288aba630fdc826f6d4da5940780f3f5536420"
-arm64.url = "https://github.com/mautrix/whatsapp/releases/download/v0.12.1/mautrix-whatsapp-arm64"
-arm64.sha256 = "ff1d0a87bf3761bc4aee2ed2c5fdb203029bd969b7a3122d6810aabeaa87dbb8"
-armhf.url = "https://github.com/mautrix/whatsapp/releases/download/v0.12.1/mautrix-whatsapp-arm"
-armhf.sha256 = "267af50d5c2fefd85504cba87d4e3c2be37442fb3ba1133416b7527a7fb5c19e"
+amd64.url = "https://github.com/mautrix/whatsapp/releases/download/v0.11.2/mautrix-whatsapp-amd64"
+amd64.sha256 = "50bfe11852096778364a6947a1f886c827ad31b27bba29b3c23af9574add1726"
+arm64.url = "https://github.com/mautrix/whatsapp/releases/download/v0.11.2/mautrix-whatsapp-arm64"
+arm64.sha256 = "e613f702ab1006a8454de30dde1625c482c54de5cc52008b92ab6a23865b3a73"
+armhf.url = "https://github.com/mautrix/whatsapp/releases/download/v0.11.2/mautrix-whatsapp-arm"
+armhf.sha256 = "152a0c9fb707842895ed1c5a489819620bf1ea60b1a27e195fa02a48ee5da608"
 
 autoupdate.strategy = "latest_github_release"
 autoupdate.asset.amd64 = "^mautrix-whatsapp-amd64$"


### PR DESCRIPTION
## Problem

- merge first this PR and later (once most people have upgraded) merge     https://github.com/YunoHost-Apps/mautrix_whatsapp_ynh/issues/172

- DB migration from 0.10.9 to 0.12.1 was not handled because 0.10.9 considered too old

- the fix published upstream to migrate the DB seems to result in issues, e.g. wrong read status https://forum.yunohost.org/t/mautrix-whatsapp-failed-to-log-in-outdated-client-the-bridge-must-be-updated-to-continue/37068/4

## Solution

- upgrade first to 0.11.2, hope it fixes the DB issues, and then one week later merge 0.12.2 in master

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
