### PR TITLE
Fix sources format (not zip, but binary)

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -98,7 +98,7 @@ main.default = 8449
 
 [resources.sources.main]
 in_subdir = false
-extract = true
+extract = false
 rename = "mautrix-whatsapp"
 amd64.url = "https://github.com/mautrix/whatsapp/releases/download/v0.12.2/mautrix-whatsapp-amd64"
 amd64.sha256 = "35a35693a0249941f9fd1e0fa8ee43da384b4dea2faeb6b103469a474d7c7c24"

--- a/manifest.toml
+++ b/manifest.toml
@@ -98,7 +98,6 @@ main.default = 8449
 
 [resources.sources.main]
 in_subdir = false
-format = "zip"
 extract = true
 rename = "mautrix-whatsapp"
 amd64.url = "https://github.com/mautrix/whatsapp/releases/download/v0.12.2/mautrix-whatsapp-amd64"


### PR DESCRIPTION
## Problem

- *Sources are not zip files but binaries*

## Solution

- *Update manifest.toml to avoid the extraction step*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
