### PR TITLE
Fix CI: Remove upgrade tests from older versions

### DIFF
--- a/tests.toml
+++ b/tests.toml
@@ -32,13 +32,6 @@ args.botusers = "server.name"
 # Commits to test upgrade from
 # -------------------------------
 
-test_upgrade_from.1d57a3b.name = "Upgrade from 0.7.2" # After config panel was implemented
-
-test_upgrade_from.ede12ed.name = "Upgrade from 0.8.0"
-
-test_upgrade_from.1e5340f.name = "Upgrade from 0.10.9"
-
-
 # This is an additional test suite
 [multiple_botusers]
 


### PR DESCRIPTION
Copied from https://github.com/YunoHost-Apps/mautrix_whatsapp_ynh/pull/171#issuecomment-3016805160 

> Upgrade tests from quite old versions cannot work because of the synapse install_dir change, making theses versions not installable with current synapse version :
> 
> Upgrade from 0.7.2 `14941 WARNING ./install: line 144: /opt/yunohost/matrix-synapse/update_synapse_for_appservice.sh: No such file or directory`
> Upgrade from 0.8.0 `15478 WARNING ./install: line 144: /opt/yunohost/matrix-synapse/update_synapse_for_appservice.sh: No such file or directory`
> Upgrade from 0.10.9 `15272 WARNING ./install: line 111: /opt/yunohost/matrix-synapse/update_synapse_for_appservice.sh: No such file or directory`
> 
> Thus, I am removing theses upgrade tests.